### PR TITLE
bugfix: Time-out alert box only visible if timetables are present

### DIFF
--- a/UPtables/app/controllers/timetables_controller.rb
+++ b/UPtables/app/controllers/timetables_controller.rb
@@ -1,7 +1,7 @@
 class TimetablesController < ApplicationController
   def index
     @timetables = Timetable.all
-    @optimum_found = @timetables.any? {|t| t.optimum? }
+    @timed_out = (@timetables.present? && @timetables.none? {|t| t.optimum? })
   end
 
   def show

--- a/UPtables/app/views/timetables/index.html.haml
+++ b/UPtables/app/views/timetables/index.html.haml
@@ -6,8 +6,8 @@
       = number_field_tag :time_out, 5
       = submit_tag "Solve!"
 
-- unless @optimum_found
-  %p.alert.alert-danger{:role => :alert} Timed out before optimal solution could be found
+- if @timed_out
+  %p.alert.alert-danger.timed-out{:role => :alert} Timed out before optimal solution could be found
 
 %table.table
   %tbody

--- a/UPtables/features/asp_timeout.feature
+++ b/UPtables/features/asp_timeout.feature
@@ -18,6 +18,12 @@ um je nach Situation schnellere oder bessere Ergebnisse zu bekommen.
     Und alle Kurse gehören zu einer Studienordnung
     Und es gibt 5 Räume mit jeweils 10 Plätzen in der Datenbank
 
+
+  Szenario: Meldung wird nicht angezeigt, wenn keine Lösungen vorhanden sind
+    Wenn ich auf die Stundenplan Seite gehe
+    Und es keine Stundenpläne gibt
+    Dann sollte auch keine Meldung vorhanden sein, dass keine optimale Lösung gefunden wurde
+
   Szenario: Eine Sekunde Time out
     Wenn ich auf die Stundenplan Seite gehe
     Und ich einen Time out von einer Sekunde einstelle

--- a/UPtables/features/step_definitions/steps.rb
+++ b/UPtables/features/step_definitions/steps.rb
@@ -193,7 +193,7 @@ Dann(/^habe ich nach kaum mehr als einer Sekunde schon Ergebnisse$/) do
 end
 
 Dann(/^wie ich sehe, wurde keine optimale Lösung gefunden$/) do
-  expect(page).to have_text("Timed out before optimal solution could be found")
+  expect(page).to have_css(".timed-out")
 end
 
 Angenommen(/^es gibt die Studienordnung "(.*?)"$/) do |curriculum|
@@ -248,3 +248,10 @@ Dann(/^der Kurs hat keine Empfehlung für irgendeine Studienordnung$/) do
   expect(@course.recommendations).to be_empty
 end
 
+Wenn(/^es keine Stundenpläne gibt$/) do
+  expect(Timetable.count).to eq 0
+end
+
+Dann(/^sollte auch keine Meldung vorhanden sein, dass keine optimale Lösung gefunden wurde$/) do
+  expect(page).not_to have_css(".timed-out")
+end


### PR DESCRIPTION
@felixKubicek have a look